### PR TITLE
Windows/Linux lack a cmd key - FIXED

### DIFF
--- a/keymaps/maximize-panes.cson
+++ b/keymaps/maximize-panes.cson
@@ -7,5 +7,17 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace .editor:not(.mini)':
-  'cmd-shift-enter': 'maximize-panes:maximize'
+
+# keymaps for OSX
+'.platform-darwin .workspace .editor:not(.mini)':
+  'cmd-alt-=': 'resize-panes:enlarge-active-pane'
+  'cmd-alt--': 'resize-panes:shrink-active-pane'
+
+# commands for windows and Linux due to their lack of an cmd key
+'.platform-win32 .workspace .editor:not(.mini)':
+  'ctrl-alt-=': 'resize-panes:enlarge-active-pane'
+  'ctrl-alt--': 'resize-panes:shrink-active-pane'
+
+'.platform-linux .workspace .editor:not(.mini)':
+  'ctrl-alt-=': 'resize-panes:enlarge-active-pane'
+  'ctrl-alt--': 'resize-panes:shrink-active-pane'


### PR DESCRIPTION
Due to the lack of a cmd key on linux and windows you were not able to use this plugin on these OSs.
