### PR TITLE
Fix if your right panes aren't maximizing (horizontally) w/ minor refactor

### DIFF
--- a/lib/maximize-panes.coffee
+++ b/lib/maximize-panes.coffee
@@ -2,8 +2,6 @@ $ = require 'jquery'
 {CompositeDisposable} = require 'atom'
 
 module.exports =
-  subscriptions: null
-
   activate: (state) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace', 'maximize-panes:maximize': => @maximize()

--- a/styles/maximize-panes.less
+++ b/styles/maximize-panes.less
@@ -8,16 +8,16 @@ html.maximize-pane-on {
   atom-pane-container {
     position:relative;
     atom-pane.active {
-      position:fixed;
+      position:absolute;
       top: 0;
       right: 0;
       left: 0;
       bottom: 0;
-      margin: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
       z-index: 100;
+    }
+    atom-pane:not(.active) {
+      position: absolute;
+      width: 0%;
     }
   }
 }

--- a/styles/maximize-panes.less
+++ b/styles/maximize-panes.less
@@ -8,11 +8,15 @@ html.maximize-pane-on {
   atom-pane-container {
     position:relative;
     atom-pane.active {
-      position:absolute;
+      position:fixed;
       top: 0;
       right: 0;
       left: 0;
       bottom: 0;
+      margin: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
       z-index: 100;
     }
   }


### PR DESCRIPTION
I'm not sure why but my right panes would go fullscreen but my right panes wouldn't. Maybe it's a plugin I'm using (which all I used is minimap and a few style plugins) but I'm not sure. I added a few css attributes which fixed my problem though
