### PR TITLE
add dotted line around maximized pane as an option

### DIFF
--- a/lib/maximize-panes.coffee
+++ b/lib/maximize-panes.coffee
@@ -2,6 +2,13 @@ $ = require 'jquery'
 {CompositeDisposable} = require 'atom'
 
 module.exports =
+
+  config:
+    border:
+      type: 'boolean'
+      default: false
+      description: 'Show dotted border around maximised pane'
+
   subscriptions: null
 
   activate: (state) ->
@@ -10,6 +17,8 @@ module.exports =
 
   maximize: ->
     $('html').toggleClass('maximize-pane-on')
+    if atom.config.get 'maximize-panes.border'
+      $('atom-pane.active').toggleClass('dotted-border')
 
   deactivate: ->
     @subscriptions.dispose()

--- a/styles/maximize-panes.less
+++ b/styles/maximize-panes.less
@@ -17,3 +17,9 @@ html.maximize-pane-on {
     }
   }
 }
+
+atom-pane.active.dotted-border {
+  outline: 2px dotted #808080;
+  outline-offset: -2px;
+  border: solid 2px #202020;
+}


### PR DESCRIPTION
When using this package I often find it difficult to remember whether a pane is maximised, or whether it is simply the only pane open.

By adding a dotted line around the pane when it is maximised, it gives a user more context about their editing environment and more closely resembles the same Ctrl-Shift-Enter feature from iTerm2.

Thought I'd add it as an (off by default) option in the package's settings so it doesn't change existing behaviour for users.
